### PR TITLE
Fixed a bug that caused double normalization and poor tracking performance

### DIFF
--- a/demo_bottrack_onnx_tflite.py
+++ b/demo_bottrack_onnx_tflite.py
@@ -448,7 +448,7 @@ class STrack(BaseTrack):
         self.alpha = 0.9
 
     def update_features(self, feature: np.ndarray):
-        feature /= np.linalg.norm(feature)
+        # feature /= np.linalg.norm(feature)
         self.curr_feature = feature
         if self.smooth_feature is None:
             self.smooth_feature = feature


### PR DESCRIPTION
- Fixed a bug that caused double normalization and poor tracking performance.
  - Since the initial normalization of the features has already been performed within Feature Extractor.
    ![image](https://github.com/PINTO0309/BoT-SORT-ONNX-TensorRT/assets/33194443/ad5ffce0-b52c-4673-bf37-fb4717634645)
